### PR TITLE
Resolve: Enable Git LFS to Track Relevant File Extensions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.obj filter=lfs diff=lfs merge=lfs -text
+*.glb filter=lfs diff=lfs merge=lfs -text
+*.png filter=lfs diff=lfs merge=lfs -text
+*.dae filter=lfs diff=lfs merge=lfs -text
+*.mtl filter=lfs diff=lfs merge=lfs -text
+*.stl filter=lfs diff=lfs merge=lfs -text
+*.abc filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
**_What was done_**
Added the following file extensions to track to `.gitattributes`
- `.obj`
- `.stl`
- `.mtl`
- `.dae`
- `.abc`
- `.png`
- `.glb`
- `.jpeg`

To understand what was done, the reviewer should

- INSTALL GIT LFS
- Checkout the branch
- Review the added files

**_Updated files_**
Updated `.gitattributes` 